### PR TITLE
Add workflow_id parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tinybird_token: ${{ secrets.TINYBIRD_CI_TOKEN }}
           tinybird_datasource: "ci_workflows_test"
+          workflow_id: "testing-workflow-id-param"

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
     description: 'The Tinybird datasource to which to push the data to'
     required: true
     default: 'ci_workflows'
+  workflow_id:
+    description: 'The id of the workflow'
+  
 
 runs:
   using: node20


### PR DESCRIPTION
This PR adds adds the missing workflow_id parameter to the action.yml. Using the action when defining this parameter led to warnings, which will be resolved with adding this.