### PR TITLE
add workflow URL to event payload

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -29035,6 +29035,7 @@ exports.pushToTinybird = exports.createWorkflowEvent = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const github = __importStar(__nccwpck_require__(5438));
 async function createWorkflowEvent(start, end, workflow_id = '', outcome) {
+    const attempt = parseInt(process.env.GITHUB_RUN_ATTEMPT, 10);
     const event = {
         run_id: github.context.runId.toString(),
         start,
@@ -29043,8 +29044,9 @@ async function createWorkflowEvent(start, end, workflow_id = '', outcome) {
         branch: github.context.ref.split('/').pop() || '',
         workflow: workflow_id === '' ? github.context.workflow : workflow_id,
         repository: `${github.context.repo.owner}/${github.context.repo.repo}`,
-        attempt: parseInt(process.env.GITHUB_RUN_ATTEMPT, 10),
-        outcome
+        attempt,
+        outcome,
+        workflow_url: `${github.context.serverUrl}/${github.context.repo.owner}/${github.context.repo.repo}/actions/runs/${github.context.runId}/attempts/${attempt}`
     };
     return event;
 }

--- a/src/tb.ts
+++ b/src/tb.ts
@@ -11,6 +11,7 @@ type WorkflowEvent = {
   repository: string
   attempt: number
   outcome: string
+  workflow_url: string
 }
 
 export async function createWorkflowEvent(
@@ -19,6 +20,7 @@ export async function createWorkflowEvent(
   workflow_id = '',
   outcome: string
 ): Promise<WorkflowEvent> {
+  const attempt = parseInt(process.env.GITHUB_RUN_ATTEMPT as string, 10)
   const event: WorkflowEvent = {
     run_id: github.context.runId.toString(),
     start,
@@ -27,8 +29,9 @@ export async function createWorkflowEvent(
     branch: github.context.ref.split('/').pop() || '',
     workflow: workflow_id === '' ? github.context.workflow : workflow_id,
     repository: `${github.context.repo.owner}/${github.context.repo.repo}`,
-    attempt: parseInt(process.env.GITHUB_RUN_ATTEMPT as string, 10),
-    outcome
+    attempt,
+    outcome,
+    workflow_url: `${github.context.serverUrl}/${github.context.repo.owner}/${github.context.repo.repo}/actions/runs/${github.context.runId}/attempts/${attempt}`
   }
   return event
 }


### PR DESCRIPTION
# Motivation
When analyzing the data, the URL would be very helpful.
This PR adds the URL of the workflow run (attempt) to the workflow event.

# Changes
- Adds the workflow URL (built from contextual data) to the workflow event being sent to Tinybird.

## Testing
- The CI action run can be analyzed to see if the reporting works correctly.