### PR TITLE
update dependabot to create fewer PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     groups:
       actions:
         patterns:
@@ -12,7 +12,7 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     groups:
       npm:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,22 +5,15 @@ updates:
     schedule:
       interval: weekly
     groups:
-      actions-minor:
-        update-types:
-          - minor
-          - patch
+      actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
     groups:
-      npm-development:
-        dependency-type: development
-        update-types:
-          - minor
-          - patch
-      npm-production:
-        dependency-type: production
-        update-types:
-          - patch
+      npm:
+        patterns:
+          - "*"


### PR DESCRIPTION
# Motivation
Dependabot is creating a lot of PRs in this repo, this PR change the config to create less PRs less often by:
- Combining some updates into single PRs.
- Changing the frequency: This action doesn't have to be changed so often, which means there aren't often releases. Dependency updates between releases aren't really affecting anyone anyways.

# Changes
- Changes the Dependabot config to:
  - Combine all `npm` updates into a single group (instead of splitting between `dev` and `prod` deps)
  - Execute the update monthly instead of weekly.
