### PR TITLE
Ignore TypeScript major updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,11 @@ updates:
       interval: monthly
     cooldown:
       default-days: 7
+    ignore:
+      # typescript-eslint does not support TypeScript 7 yet (needs the stable
+      # tsgo API targeted for TS 7.1); drop this once it does
+      - dependency-name: typescript
+        update-types: ['version-update:semver-major']
     groups:
       npm:
         patterns:


### PR DESCRIPTION
typescript-eslint cannot run on TypeScript 7 until the stable tsgo programmatic API lands (targeted for TS 7.1, autumn 2026), so the TS 6→7 major bump in #37 makes `npm ci` fail with a peer-dependency conflict and blocks the other 10 updates in the npm group.

This adds a dependabot ignore rule for TypeScript major version updates. Once this is merged, recreating #37 (`@dependabot recreate`) will regenerate the group without the TS 7 bump so the remaining updates can land. Drop the rule once typescript-eslint supports TS 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)